### PR TITLE
fix: make auto-approve actually work

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-    if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && (github.event.pull_request.user.login == 'DanielMSchmidt' || github.event.pull_request.user.login == 'github-bot')
+    if: contains(github.event.pull_request.labels.*.name, 'auto-approve') && (github.event.pull_request.user.login == 'team-tf-cdk')
     steps:
       - uses: hmarr/auto-approve-action@v2.2.1
         with:

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -75,7 +75,7 @@ jobs:
             *Automatically created by projen via the "upgrade-main" workflow*
           branch: github-actions/upgrade-main
           title: "chore(deps): upgrade dependencies"
-          labels: auto-approve
+          labels: auto-approve,dependencies
           body: |-
             Upgrades project dependencies. See details in [workflow run].
 

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -40,7 +40,12 @@ const project = new JsiiProject({
   autoApproveUpgrades: true,
   autoApproveOptions: {
     label: "auto-approve",
-    allowedUsernames: ["DanielMSchmidt", "github-bot"],
+    allowedUsernames: ["team-tf-cdk"],
+  },
+  depsUpgradeOptions: {
+    workflowOptions: {
+      labels: ["auto-approve", "dependencies"],
+    },
   },
   gitignore: [".idea/"],
   workflowGitIdentity: {


### PR DESCRIPTION
Realized this wasn't working because our upgrade PRs come from team-tf-cdk and not github-actions[bot]