### PR TITLE
chore: switch to weekly dependency updates

### DIFF
--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -4,7 +4,7 @@ name: upgrade-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 0 * * 1
 jobs:
   upgrade:
     name: Upgrade

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -1,6 +1,6 @@
 import { IResolver, License } from "projen";
 import { JsiiProject } from "projen/lib/cdk";
-import { NpmAccess } from "projen/lib/javascript";
+import { NpmAccess, UpgradeDependenciesSchedule } from "projen/lib/javascript";
 import { TypeScriptProject } from "projen/lib/typescript";
 
 const SPDX = "MPL-2.0";
@@ -45,6 +45,7 @@ const project = new JsiiProject({
   depsUpgradeOptions: {
     workflowOptions: {
       labels: ["auto-approve", "dependencies"],
+      schedule: UpgradeDependenciesSchedule.WEEKLY,
     },
   },
   gitignore: [".idea/"],


### PR DESCRIPTION
Right now this codebase does a nightly release, usually because of small Projen updates, which seems like overkill and might be confusing to users who are wondering why there are so many releases. Switching to weekly should be fine for this project.