### PR TITLE
chore(ci): fix broken upgrade workflow

### DIFF
--- a/.github/workflows/upgrade-cdktf.yml
+++ b/.github/workflows/upgrade-cdktf.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Get current CDKTF version
         id: current_version
         run: |-
-          OLD_VERSION=$(cd examples/hybrid-module && npm list cdktf --depth=0 --json | jq -r '.dependencies.cdktf.version')
+          OLD_VERSION=$(cd examples/hybrid-module && yarn && npm list cdktf --depth=0 --json | jq -r '.dependencies.cdktf.version')
           OLD_VERSION_SHORT=$(cut -d "." -f 2 <<< "$OLD_VERSION")
           echo "value=$OLD_VERSION" >> $GITHUB_OUTPUT
           echo "short=$OLD_VERSION_SHORT" >> $GITHUB_OUTPUT
@@ -37,8 +37,11 @@ jobs:
       - name: Run upgrade script
         if: steps.current_version.outputs.short != steps.latest_version.outputs.short
         run: scripts/update-cdktf.sh ${{ steps.latest_version.outputs.value }}
+      - name: Check if there are any changes
+        id: get_changes
+        run: echo "changed=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT
       - name: Create draft pull request
-        if: steps.current_version.outputs.short != steps.latest_version.outputs.short
+        if: steps.get_changes.outputs.changed != 0
         uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666
         with:
           commit-message: "chore!: upgrade to cdktf ${{ steps.latest_version.outputs.value }}"

--- a/.github/workflows/upgrade-cdktf.yml
+++ b/.github/workflows/upgrade-cdktf.yml
@@ -20,10 +20,12 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
       - name: Install
         run: yarn install
+      - name: Install examples
+        run: ls -d examples/* | xargs -I {} bash -c "cd '{}' && yarn"
       - name: Get current CDKTF version
         id: current_version
         run: |-
-          OLD_VERSION=$(cd examples/hybrid-module && yarn && npm list cdktf --depth=0 --json | jq -r '.dependencies.cdktf.version')
+          OLD_VERSION=$(cd examples/hybrid-module && npm list cdktf --depth=0 --json | jq -r '.dependencies.cdktf.version')
           OLD_VERSION_SHORT=$(cut -d "." -f 2 <<< "$OLD_VERSION")
           echo "value=$OLD_VERSION" >> $GITHUB_OUTPUT
           echo "short=$OLD_VERSION_SHORT" >> $GITHUB_OUTPUT

--- a/projenrc/upgrade-cdktf.ts
+++ b/projenrc/upgrade-cdktf.ts
@@ -36,10 +36,14 @@ export class UpgradeCDKTF {
             run: "yarn install",
           },
           {
+            name: "Install examples",
+            run: `ls -d examples/* | xargs -I {} bash -c "cd '{}' && yarn"`,
+          },
+          {
             name: "Get current CDKTF version",
             id: "current_version",
             run: [
-              `OLD_VERSION=$(cd examples/hybrid-module && yarn && npm list cdktf --depth=0 --json | jq -r '.dependencies.cdktf.version')`,
+              `OLD_VERSION=$(cd examples/hybrid-module && npm list cdktf --depth=0 --json | jq -r '.dependencies.cdktf.version')`,
               `OLD_VERSION_SHORT=$(cut -d "." -f 2 <<< "$OLD_VERSION")`,
               `echo "value=$OLD_VERSION" >> $GITHUB_OUTPUT`,
               `echo "short=$OLD_VERSION_SHORT" >> $GITHUB_OUTPUT`,

--- a/projenrc/upgrade-cdktf.ts
+++ b/projenrc/upgrade-cdktf.ts
@@ -39,7 +39,7 @@ export class UpgradeCDKTF {
             name: "Get current CDKTF version",
             id: "current_version",
             run: [
-              `OLD_VERSION=$(cd examples/hybrid-module && npm list cdktf --depth=0 --json | jq -r '.dependencies.cdktf.version')`,
+              `OLD_VERSION=$(cd examples/hybrid-module && yarn && npm list cdktf --depth=0 --json | jq -r '.dependencies.cdktf.version')`,
               `OLD_VERSION_SHORT=$(cut -d "." -f 2 <<< "$OLD_VERSION")`,
               `echo "value=$OLD_VERSION" >> $GITHUB_OUTPUT`,
               `echo "short=$OLD_VERSION_SHORT" >> $GITHUB_OUTPUT`,
@@ -64,8 +64,13 @@ export class UpgradeCDKTF {
             run: "scripts/update-cdktf.sh ${{ steps.latest_version.outputs.value }}",
           },
           {
+            name: "Check if there are any changes",
+            id: "get_changes",
+            run: `echo "changed=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT`,
+          },
+          {
             name: "Create draft pull request",
-            if: "steps.current_version.outputs.short != steps.latest_version.outputs.short",
+            if: "steps.get_changes.outputs.changed != 0",
             uses: "peter-evans/create-pull-request@v3",
             with: {
               "commit-message":


### PR DESCRIPTION
It was still creating a new PR because of issues determining the previous CDKTF version. This fixes it.