### PR TITLE
chore(ci): update required version of constructs when cdktf is upgraded

### DIFF
--- a/.github/MAINTENANCE.md
+++ b/.github/MAINTENANCE.md
@@ -43,7 +43,6 @@ The following Actions either need to be manually triggered or require significan
   2. Update the [object](https://github.com/cdktf/projen-cdktf-hybrid-construct/blob/4ea42f59370a23fbdc5d3acd6f3a08a7f6dfd254/.projenrc.ts#L21-L32)
   3. Run `npx projen`
   4. Create a new PR with the title `chore(deps): update pinned versions of GitHub Actions`
-- **`constructs` library upgrades**: Because `constructs` is a peer dependency, the `upgrade-main` script described above will _never_ increment its version; this will always need to be done manually by [editing](https://github.com/cdktf/projen-cdktf-hybrid-construct/blob/4ea42f59370a23fbdc5d3acd6f3a08a7f6dfd254/.projenrc.ts#L70) `.projenrc.ts`. This could _in theory_ be (semi)automated like some of our other upgrade workflows described above for things like CDKTF, Node, and JSII, but in practice we currently have no logic or criteria that governs when `constructs` should be updated; as such, creating a custom workflow for it felt like more effort than it's really worth.
 
 Also worth noting: Unlike many of our other Projen-based projects, this one does not have a script that automatically upgrades Node.js because this library does not enforce a `minNodeVersion`. If we did at some point want to start enforcing a `minNodeVersion`, we should copy over the `upgrade-node` script that our other Projen projects use.
 

--- a/.github/workflows/upgrade-cdktf.yml
+++ b/.github/workflows/upgrade-cdktf.yml
@@ -41,11 +41,14 @@ jobs:
         run: |-
           CDKTF_VERSION=$(yarn info cdktf --json | jq -r '.data.version')
           CDKTF_VERSION_SHORT=$(cut -d "." -f 2 <<< "$CDKTF_VERSION")
+          CONSTRUCTS_VERSION=$(yarn info cdktf --json | jq -r '.data.peerDependencies.constructs')
+          CONSTRUCTS_VERSION_EXACT=$(cut -d "^" -f 2 <<< "$CONSTRUCTS_VERSION")
           echo "value=$CDKTF_VERSION" >> $GITHUB_OUTPUT
           echo "short=$CDKTF_VERSION_SHORT" >> $GITHUB_OUTPUT
+          echo "constructs=$CONSTRUCTS_VERSION_EXACT" >> $GITHUB_OUTPUT
       - name: Run upgrade script
         if: steps.current_version.outputs.short != steps.latest_version.outputs.short
-        run: scripts/update-cdktf.sh ${{ steps.latest_version.outputs.value }}
+        run: scripts/update-cdktf.sh ${{ steps.latest_version.outputs.value }} ${{ steps.latest_version.outputs.constructs }}
       - name: Check if there are any changes
         id: get_changes
         run: echo "changed=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -143,6 +143,11 @@
     },
     {
       "name": "constructs",
+      "version": "10.3.0",
+      "type": "override"
+    },
+    {
+      "name": "constructs",
       "version": ">= 10.3.0",
       "type": "peer"
     },

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -46,7 +46,7 @@
     },
     {
       "name": "constructs",
-      "version": "^10.0.0",
+      "version": "10.3.0",
       "type": "build"
     },
     {
@@ -143,7 +143,7 @@
     },
     {
       "name": "constructs",
-      "version": "^10.4.2",
+      "version": ">= 10.3.0",
       "type": "peer"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -14,7 +14,8 @@ import { UpgradeJSIIAndTypeScript } from "./projenrc/upgrade-jsii-typescript";
 import { UpgradeProjen } from "./projenrc/upgrade-projen";
 
 const name = "projen-cdktf-hybrid-construct";
-/** JSII and TSII should always use the same major/minor version range */
+const constructsVersion = "10.3.0";
+/** JSII and TS should always use the same major/minor version range */
 const typescriptVersion = "~5.5.0";
 const projenVersion = "0.88.0";
 
@@ -67,12 +68,16 @@ project.tsconfig?.exclude?.push("src/exampleCode/**");
 project.tsconfig?.exclude?.push("example/**");
 project.tsconfig?.exclude?.push("examples/**");
 
-project.addPeerDeps(`projen@>= ${projenVersion}`, "constructs@^10.4.2");
+project.addPeerDeps(
+  `projen@>= ${projenVersion}`,
+  `constructs@>= ${constructsVersion}`
+);
 project.addBundledDeps("change-case");
 project.addDevDeps(
   "fs-extra",
   "glob",
   `projen@${projenVersion}`,
+  `constructs@${constructsVersion}`,
   "semver",
   "@types/semver",
   "@types/fs-extra",

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -86,6 +86,10 @@ project.addDevDeps(
   "ts-node@10.9.1",
   "comment-json"
 );
+// This gets rid of the following error during the build » package » package-all » package:js step:
+// Error: Conflicting versions of constructs in type system: previously loaded 10.3.0, trying to load 10.4.2
+// It is not clear why the above error occurs; none of our other Projen projects have this problem
+project.package.addPackageResolutions(`constructs@${constructsVersion}`);
 
 new CustomizedLicense(project);
 new AutoApprove(project);

--- a/API.md
+++ b/API.md
@@ -5593,7 +5593,7 @@ public readonly constructVersion: string;
 ```
 
 - *Type:* string
-- *Default:* "^10.0.107"
+- *Default:* "^10.3.0"
 
 Construct version to use.
 
@@ -8231,7 +8231,7 @@ public readonly constructVersion: string;
 ```
 
 - *Type:* string
-- *Default:* "^10.0.107"
+- *Default:* "^10.3.0"
 
 Construct version to use.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ By using the software in this repository, you acknowledge that:
 ## Compatibility
 
 - `cdktf` >= 0.20.0
-- `constructs` >= 10.4.2
+- `constructs` >= 10.3.0
 - `projen` >= 0.88.0
 
 ## Usage

--- a/examples/hybrid-module/.projen/deps.json
+++ b/examples/hybrid-module/.projen/deps.json
@@ -36,7 +36,7 @@
     },
     {
       "name": "constructs",
-      "version": "^10.0.0",
+      "version": "10.3.0",
       "type": "build"
     },
     {
@@ -121,7 +121,7 @@
     },
     {
       "name": "constructs",
-      "version": ">=10.4.2",
+      "version": ">=10.3.0",
       "type": "peer"
     },
     {

--- a/examples/hybrid-module/package.json
+++ b/examples/hybrid-module/package.json
@@ -42,7 +42,7 @@
     "cdktf": "0.20.0",
     "cdktf-cli": "~0.20.0",
     "commit-and-tag-version": "^12",
-    "constructs": "10.4.2",
+    "constructs": "10.3.0",
     "eslint": "^8",
     "eslint-config-prettier": "^8.10.0",
     "eslint-import-resolver-typescript": "^2.7.1",
@@ -63,7 +63,7 @@
   },
   "peerDependencies": {
     "cdktf": ">=0.20.0",
-    "constructs": ">=10.4.2"
+    "constructs": ">=10.3.0"
   },
   "dependencies": {
     "@cdktf/tf-module-stack": ">=5.0.0"

--- a/examples/hybrid-module/yarn.lock
+++ b/examples/hybrid-module/yarn.lock
@@ -2167,7 +2167,7 @@ constructs@10.3.0:
   resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.3.0.tgz#4c246fce9cf8e77711ad45944e9fbd41f1501965"
   integrity sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==
 
-constructs@10.4.2, constructs@^10.0.0:
+constructs@^10.0.0:
   version "10.4.2"
   resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.4.2.tgz#e875a78bef932cca12ea63965969873a25c1c132"
   integrity sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==

--- a/examples/terraform-module/.projen/deps.json
+++ b/examples/terraform-module/.projen/deps.json
@@ -36,7 +36,7 @@
     },
     {
       "name": "constructs",
-      "version": "^10.0.0",
+      "version": "10.3.0",
       "type": "build"
     },
     {
@@ -121,7 +121,7 @@
     },
     {
       "name": "constructs",
-      "version": ">=10.4.2",
+      "version": ">=10.3.0",
       "type": "peer"
     }
   ],

--- a/examples/terraform-module/package.json
+++ b/examples/terraform-module/package.json
@@ -41,7 +41,7 @@
     "cdktf": "0.20.0",
     "cdktf-cli": "~0.20.0",
     "commit-and-tag-version": "^12",
-    "constructs": "10.4.2",
+    "constructs": "10.3.0",
     "eslint": "^8",
     "eslint-config-prettier": "^8.10.0",
     "eslint-import-resolver-typescript": "^2.7.1",
@@ -62,7 +62,7 @@
   },
   "peerDependencies": {
     "cdktf": ">=0.20.0",
-    "constructs": ">=10.4.2"
+    "constructs": ">=10.3.0"
   },
   "keywords": [
     "cdk",

--- a/examples/terraform-module/yarn.lock
+++ b/examples/terraform-module/yarn.lock
@@ -2162,7 +2162,7 @@ constructs@10.3.0:
   resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.3.0.tgz#4c246fce9cf8e77711ad45944e9fbd41f1501965"
   integrity sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==
 
-constructs@10.4.2, constructs@^10.0.0:
+constructs@^10.0.0:
   version "10.4.2"
   resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.4.2.tgz#e875a78bef932cca12ea63965969873a25c1c132"
   integrity sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==

--- a/package.json
+++ b/package.json
@@ -82,6 +82,9 @@
   "bundledDependencies": [
     "change-case"
   ],
+  "resolutions": {
+    "constructs": "10.3.0"
+  },
   "main": "lib/index.js",
   "license": "MPL-2.0",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@typescript-eslint/parser": "^7",
     "comment-json": "^4.2.5",
     "commit-and-tag-version": "^12",
-    "constructs": "10.4.2",
+    "constructs": "10.3.0",
     "eslint": "^8",
     "eslint-config-prettier": "^8.10.0",
     "eslint-import-resolver-typescript": "^2.7.1",
@@ -73,7 +73,7 @@
     "typescript": "~5.5.0"
   },
   "peerDependencies": {
-    "constructs": "^10.4.2",
+    "constructs": ">= 10.3.0",
     "projen": ">= 0.88.0"
   },
   "dependencies": {

--- a/projenrc/upgrade-cdktf.ts
+++ b/projenrc/upgrade-cdktf.ts
@@ -69,8 +69,11 @@ export class UpgradeCDKTF {
             run: [
               `CDKTF_VERSION=$(yarn info cdktf --json | jq -r '.data.version')`,
               `CDKTF_VERSION_SHORT=$(cut -d "." -f 2 <<< "$CDKTF_VERSION")`,
+              `CONSTRUCTS_VERSION=$(yarn info cdktf --json | jq -r '.data.peerDependencies.constructs')`,
+              `CONSTRUCTS_VERSION_EXACT=$(cut -d "^" -f 2 <<< "$CONSTRUCTS_VERSION")`, // strip the caret off the beginning
               `echo "value=$CDKTF_VERSION" >> $GITHUB_OUTPUT`,
               `echo "short=$CDKTF_VERSION_SHORT" >> $GITHUB_OUTPUT`,
+              `echo "constructs=$CONSTRUCTS_VERSION_EXACT" >> $GITHUB_OUTPUT`,
             ].join("\n"),
             // IMPORTANT: the above behavior changed in Yarn 2+; `yarn info` instead gives the version of the installed package
             // If/when we upgrade we'll likely want to switch to `yarn npm info`: https://yarnpkg.com/cli/npm/info
@@ -78,7 +81,7 @@ export class UpgradeCDKTF {
           {
             name: "Run upgrade script",
             if: "steps.current_version.outputs.short != steps.latest_version.outputs.short",
-            run: "scripts/update-cdktf.sh ${{ steps.latest_version.outputs.value }}",
+            run: "scripts/update-cdktf.sh ${{ steps.latest_version.outputs.value }} ${{ steps.latest_version.outputs.constructs }}",
           },
           {
             name: "Check if there are any changes",

--- a/scripts/update-cdktf.sh
+++ b/scripts/update-cdktf.sh
@@ -6,20 +6,34 @@ set -ex
 
 PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE:-$0}")/.." && pwd)
 CDKTF_VERSION=$1
+CONSTRUCTS_VERSION=$2
 
 if [ -z "$CDKTF_VERSION" ]; then
-  echo "Usage: $0 <cdktf-version>"
+  echo "Usage: $0 <cdktf-version> <constructs-version>"
+  exit 1
+fi
+if [ -z "$CONSTRUCTS_VERSION" ]; then
+  echo "Usage: $0 <cdktf-version> <constructs-version>"
   exit 1
 fi
 
-echo "Updating /src cdktf version to $CDKTF_VERSION"
+echo "Updating self to constructs version $CONSTRUCTS_VERSION"
 yarn
+sed -i "s/constructsVersion = \".*\";/constructsVersion = \"$CONSTRUCTS_VERSION\";/" "$PROJECT_ROOT/.projenrc.ts"
+
+echo "Updating /src to cdktf version $CDKTF_VERSION"
 find ./src -type f -name "*.ts" -print0 | xargs -0 sed -i "s/const cdktfVersion = options.cdktfVersion || \".*\"/const cdktfVersion = options.cdktfVersion || \"$CDKTF_VERSION\"/"
 # @TODO This is a hack and will stop working when CDKTF goes 1.0
 find ./src -type f -name "*.ts" -print0 | xargs -0 sed -i "s/@default \"0\..*\"/@default \"$CDKTF_VERSION\"/"
 
+echo "Updating /src to constructs version $CONSTRUCTS_VERSION"
+find ./src -type f -name "*.ts" -print0 | xargs -0 sed -i "s/const constructVersion = options.constructVersion || \".*\"/const constructVersion = options.constructVersion || \"$CONSTRUCTS_VERSION\"/"
+# @TODO This is also a hack ... but it works
+find ./src -type f -name "*.ts" -print0 | xargs -0 sed -i "s/@default \"^.*\"/@default \"^$CONSTRUCTS_VERSION\"/"
+
 echo "Updating README"
 sed -i 's/`cdktf` >= .*/`cdktf` >= '"$CDKTF_VERSION"'/' "$PROJECT_ROOT/README.md"
+sed -i 's/`constructs` >= .*/`constructs` >= '"$CONSTRUCTS_VERSION"'/' "$PROJECT_ROOT/README.md"
 
 npx projen build
 

--- a/src/hybrid-module.ts
+++ b/src/hybrid-module.ts
@@ -37,7 +37,7 @@ export interface HybridModuleOptions extends ConstructLibraryOptions {
 
   /**
    * Construct version to use
-   * @default "^10.0.107"
+   * @default "^10.3.0"
    */
   readonly constructVersion?: string;
 
@@ -180,7 +180,7 @@ export class HybridModule extends JsiiProject {
       jsiiVersion: "~5.5.0",
       typescriptVersion: "~5.5.0", // should always be the same major/minor as JSII
     });
-    const constructVersion = options.constructVersion || "10.4.2";
+    const constructVersion = options.constructVersion || "10.3.0";
     const cdktfVersion = options.cdktfVersion || "0.20.0";
 
     console.log({ cdktfVersion, constructVersion });
@@ -191,6 +191,7 @@ export class HybridModule extends JsiiProject {
     this.addDevDeps(
       `cdktf@~${cdktfVersion}`,
       `cdktf-cli@~${cdktfVersion}`,
+      `constructs@${constructVersion}`,
       "ts-node@>=10.9.1",
       "jsii-docgen@^10.0.0"
     );

--- a/src/terraform-module.ts
+++ b/src/terraform-module.ts
@@ -28,7 +28,7 @@ export interface TerraformModuleOptions extends ConstructLibraryOptions {
 
   /**
    * Construct version to use
-   * @default "^10.0.107"
+   * @default "^10.3.0"
    */
   readonly constructVersion?: string;
 
@@ -64,7 +64,7 @@ export class TerraformModule extends ConstructLibrary {
       jsiiVersion: "~5.5.0",
       typescriptVersion: "~5.5.0", // should always be the same major/minor as JSII
     });
-    const constructVersion = options.constructVersion || "10.4.2";
+    const constructVersion = options.constructVersion || "10.3.0";
     const cdktfVersion = options.cdktfVersion || "0.20.0";
 
     const constructSrcCode = `
@@ -91,6 +91,7 @@ describe("MyModule", () => {
     this.addDevDeps(
       `cdktf@~${cdktfVersion}`,
       `cdktf-cli@~${cdktfVersion}`,
+      `constructs@${constructVersion}`,
       "ts-node@>=10.9.1",
       "jsii-docgen@^10.0.0"
     );

--- a/test/__snapshots__/hybrid-module.test.ts.snap
+++ b/test/__snapshots__/hybrid-module.test.ts.snap
@@ -892,7 +892,7 @@ exports[`HybridModule snapshot: package.json 1`] = `
     "cdktf": "0.20.0",
     "cdktf-cli": "~0.20.0",
     "commit-and-tag-version": "^12",
-    "constructs": "10.4.2",
+    "constructs": "10.3.0",
     "eslint": "^8",
     "eslint-config-prettier": "*",
     "eslint-import-resolver-typescript": "*",
@@ -979,7 +979,7 @@ exports[`HybridModule snapshot: package.json 1`] = `
   "name": "my-module",
   "peerDependencies": {
     "cdktf": ">=0.20.0",
-    "constructs": ">=10.4.2",
+    "constructs": ">=10.3.0",
   },
   "publishConfig": {
     "access": "public",

--- a/test/__snapshots__/terraform-module.test.ts.snap
+++ b/test/__snapshots__/terraform-module.test.ts.snap
@@ -1494,7 +1494,7 @@ exports[`TerraformModule snapshot: package.json 1`] = `
     "cdktf": "0.20.0",
     "cdktf-cli": "~0.20.0",
     "commit-and-tag-version": "^12",
-    "constructs": "10.4.2",
+    "constructs": "10.3.0",
     "eslint": "^8",
     "eslint-config-prettier": "*",
     "eslint-import-resolver-typescript": "*",
@@ -1576,7 +1576,7 @@ exports[`TerraformModule snapshot: package.json 1`] = `
   "name": "my-module",
   "peerDependencies": {
     "cdktf": ">=0.20.0",
-    "constructs": ">=10.4.2",
+    "constructs": ">=10.3.0",
   },
   "publishConfig": {
     "access": "public",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,7 +1549,12 @@ constant-case@^3.0.4:
     tslib "^2.0.3"
     upper-case "^2.0.2"
 
-constructs@10.4.2, constructs@^10.0.0:
+constructs@10.3.0:
+  version "10.3.0"
+  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.3.0.tgz#4c246fce9cf8e77711ad45944e9fbd41f1501965"
+  integrity sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==
+
+constructs@^10.0.0:
   version "10.4.2"
   resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.4.2.tgz#e875a78bef932cca12ea63965969873a25c1c132"
   integrity sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1549,15 +1549,10 @@ constant-case@^3.0.4:
     tslib "^2.0.3"
     upper-case "^2.0.2"
 
-constructs@10.3.0:
+constructs@10.3.0, constructs@^10.0.0:
   version "10.3.0"
   resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.3.0.tgz#4c246fce9cf8e77711ad45944e9fbd41f1501965"
   integrity sha512-vbK8i3rIb/xwZxSpTjz3SagHn1qq9BChLEfy5Hf6fB3/2eFbrwt2n9kHwQcS0CPTRBesreeAcsJfMq2229FnbQ==
-
-constructs@^10.0.0:
-  version "10.4.2"
-  resolved "https://registry.yarnpkg.com/constructs/-/constructs-10.4.2.tgz#e875a78bef932cca12ea63965969873a25c1c132"
-  integrity sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==
 
 conventional-changelog-angular@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
This downgrades the minimum required version of `constructs` from `10.4.2` to `10.3.0`; there should not have been a reason to upgrade the version constraint this high previously. This is not a breaking change, since anyone who had already upgraded to `constructs@10.4.2` is not affected.