### PR TITLE
chore(ci): add missing setup-terraform step to workflow

### DIFF
--- a/.github/workflows/upgrade-jsii-typescript.yml
+++ b/.github/workflows/upgrade-jsii-typescript.yml
@@ -82,6 +82,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd
+        with:
+          terraform_wrapper: false
       - name: Setup Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with: {}

--- a/projenrc/upgrade-jsii-typescript.ts
+++ b/projenrc/upgrade-jsii-typescript.ts
@@ -73,7 +73,7 @@ export class UpgradeJSIIAndTypeScript {
           {
             name: "Get the earliest supported JSII version whose EOS date is at least a month away",
             if: "${{ ! inputs.version }}",
-            uses: "actions/github-script@v6",
+            uses: "actions/github-script",
             with: {
               script: [
                 `const script = require('./scripts/check-jsii-versions.js')`,
@@ -144,6 +144,13 @@ export class UpgradeJSIIAndTypeScript {
           {
             name: "Checkout",
             uses: "actions/checkout",
+          },
+          {
+            name: "Setup Terraform",
+            uses: "hashicorp/setup-terraform",
+            with: {
+              terraform_wrapper: false,
+            },
           },
           {
             name: "Setup Node.js",


### PR DESCRIPTION
The `upgrade-jsii-typescript` workflow needs to be able to call the Terraform CLI as part of the upgrade process, so this fix is required in order for that workflow to succeed.