### PR TITLE
chore(deps): add upgrade that was missed in #219

### DIFF
--- a/examples/hybrid-module/.projen/deps.json
+++ b/examples/hybrid-module/.projen/deps.json
@@ -126,7 +126,7 @@
     },
     {
       "name": "@cdktf/tf-module-stack",
-      "version": ">=5.0.0",
+      "version": ">=7.0.0",
       "type": "runtime"
     }
   ],

--- a/examples/hybrid-module/package.json
+++ b/examples/hybrid-module/package.json
@@ -66,7 +66,7 @@
     "constructs": ">=10.4.2"
   },
   "dependencies": {
-    "@cdktf/tf-module-stack": ">=5.0.0"
+    "@cdktf/tf-module-stack": ">=7.0.0"
   },
   "keywords": [
     "cdk",

--- a/examples/hybrid-module/yarn.lock
+++ b/examples/hybrid-module/yarn.lock
@@ -450,10 +450,10 @@
     deepmerge "4.3.1"
     fs-extra "11.3.0"
 
-"@cdktf/tf-module-stack@>=5.0.0":
-  version "6.0.22"
-  resolved "https://registry.yarnpkg.com/@cdktf/tf-module-stack/-/tf-module-stack-6.0.22.tgz#104a55da331306b0bbd12d2215aa98382249ec29"
-  integrity sha512-toLAFgXl0dpRgzsRbS2GBfeEEEtynHzMpzeetqcxHCzCfNx4/lL4/3d2sMvScJYKIfieyP2HT59Hhttqum0TiQ==
+"@cdktf/tf-module-stack@>=7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@cdktf/tf-module-stack/-/tf-module-stack-7.0.0.tgz#eb1e913e80e9833fd17f688099c0a9b87b8143cd"
+  integrity sha512-bSkd+753tKE+gePtm79O/YuEUxxSH3CRKXK5yIZTUDrpdHin8RUCnKzJX9bCa6yPWAGS2ARgpV6brt3+90wCGg==
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"

--- a/src/hybrid-module.ts
+++ b/src/hybrid-module.ts
@@ -202,7 +202,7 @@ export class HybridModule extends JsiiProject {
     this.setScript("terraform:test", "./scripts/tf-module-test.sh");
 
     // Module Entrypoint
-    this.addDeps("@cdktf/tf-module-stack@>=5.0.0");
+    this.addDeps("@cdktf/tf-module-stack@>=7.0.0");
     const moduleDocs = `
 # My Awesome Module
 

--- a/test/__snapshots__/hybrid-module.test.ts.snap
+++ b/test/__snapshots__/hybrid-module.test.ts.snap
@@ -882,7 +882,7 @@ exports[`HybridModule snapshot: package.json 1`] = `
     "organization": false,
   },
   "dependencies": {
-    "@cdktf/tf-module-stack": ">=5.0.0",
+    "@cdktf/tf-module-stack": ">=7.0.0",
   },
   "devDependencies": {
     "@types/jest": "*",


### PR DESCRIPTION
I missed the fact that the changes had gotten overwritten again by the force-push, and I guess this upgrade is one that doesn't cause any tests/builds to fail. Anyway, this should've been included in #219 but it's here now.